### PR TITLE
Fix zodiac deployment action

### DIFF
--- a/.github/workflows/build-deploy-zodiac.yml
+++ b/.github/workflows/build-deploy-zodiac.yml
@@ -20,9 +20,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Build React App
-        run: |
-          yarn dist
-          ls -l
+        run: yarn build
 
       - name: Determine Branch Name
         id: get_branch
@@ -34,5 +32,5 @@ jobs:
           server: ${{ secrets.NEUROJ_SERVER }}
           username: ${{ secrets.NEUROJ_SERVER_USER }}
           ssh_private_key: ${{ secrets.NEUROJ_SERVER_SSH_KEY }}
-          local_path: "./dist/*"
+          local_path: "./build/*"
           remote_path: "${{ secrets.NEUROJ_CI_PATH }}/${{ env.BRANCH_NAME }}"


### PR DESCRIPTION
hi @MarSH-Up, I debugged the sftp action and have to do the following to fix the broken action

1. as you suggested, fork `wlixcc/SFTP-Deploy-Action` to NeuroJSON org solved the [repo error](https://github.com/NeuroJSON/NeuroJSON_io/actions/runs/13779655970) - I have no idea why it triggers this error despite that this action is already in the [Github marketplace](https://github.com/marketplace/actions/sftp-deploy), maybe because this is a private repo?
2. I have to regenerated the ssh private key by adding `-m pem`  with ssh-keygen, so that the output is in the pem format (which has a header of `BEGIN RSA PRIVATE KEY`)
3. add the public key to `authorized_keys` file

```
ssh-keygen -m pem -t rsa -b ... -C "..."
cat id_rsa.pub >> ~/.ssh/authorized_keys
```

after the above 3 changes, the action now works

although the built webpage can be uploaded to zodiac, but the page is empty, you can take a look, I will create another issue on this (#20)

https://zodiac.coe.neu.edu/dev/dev_fang/

the body of the index.html file shows "You need to enable JavaScript to run this app."

please take a look and merge to your branch. after we fix the empty page problem, feel free to push it to staging.