### PR TITLE
Fix #37 Small refinements to the dataset level page

### DIFF
--- a/src/pages/DatasetDetailPage.tsx
+++ b/src/pages/DatasetDetailPage.tsx
@@ -586,7 +586,8 @@ const DatasetDetailPage: React.FC = () => {
 							"&:hover": { backgroundColor: "#ff9100" },
 						}}
 					>
-						Download Dataset (1 Mb)
+						{/* Download Dataset (1 Mb) */}
+						Download Dataset ({(jsonSize / 1024).toFixed(0)} MB)
 						</Button>
 
 						<Button


### PR DESCRIPTION
Here are some small fixes

- [ ] the database link to the right of the Home icon on every Dataset page is not working, for example
![Image](https://github.com/user-attachments/assets/3da6b244-4353-4bf8-8deb-4f9e206418cc)
- [ ] the text-valued JSON keys in the JSON view should have the following css setting to limit the height and use ... to overflow.
```
    overflow: clip;
    text-overflow: ellipsis;
    display: -webkit-box;
    -webkit-line-clamp: 4;
```
- [ ] in my jsonview.traverse() function, I also scan over all string-valued fields, and encloses the values with `<code class="puretext">...</code>`, and set code.puretext css with `white-space: pre-wrap;` in order to properly show the newlines in the strings
- [ ] the script to download all files button is not working, for example https://zodiac.coe.neu.edu/dev/dev_hari/databases/defenderfer-2019/S1001_run01
- [ ] the download dataset button also report incorrect file size, again, you can test it using the above link 