### PR TITLE
Search: show DatabaseCard on keyword or DB selection; dataset page polish (metadata size fix, revision dropdown) — closes #81

### DIFF
--- a/src/components/DatasetDetailPage/MetaDataPanel.tsx
+++ b/src/components/DatasetDetailPage/MetaDataPanel.tsx
@@ -1,13 +1,44 @@
-import { Box, Typography } from "@mui/material";
+import ArrowCircleRightIcon from "@mui/icons-material/ArrowCircleRight";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+import {
+  Box,
+  Typography,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  Chip,
+  IconButton,
+  Tooltip,
+} from "@mui/material";
 import { Colors } from "design/theme";
-import React from "react";
+import React, { useMemo, useState } from "react";
 
 type Props = {
   dbViewInfo: any;
   datasetDocument: any;
+  dbName: string | undefined;
+  docId: string | undefined;
 };
 
-const MetaDataPanel: React.FC<Props> = ({ dbViewInfo, datasetDocument }) => {
+type RevInfo = { rev: string };
+
+const MetaDataPanel: React.FC<Props> = ({
+  dbViewInfo,
+  datasetDocument,
+  dbName,
+  docId,
+}) => {
+  const revs: RevInfo[] = useMemo(
+    () =>
+      Array.isArray(datasetDocument?.["_revs_info"])
+        ? (datasetDocument!["_revs_info"] as RevInfo[])
+        : [],
+    [datasetDocument]
+  );
+  const [revIdx, setRevIdx] = useState(0);
+  const selected = revs[revIdx];
+
   return (
     <Box
       sx={{
@@ -39,7 +70,6 @@ const MetaDataPanel: React.FC<Props> = ({ dbViewInfo, datasetDocument }) => {
             {dbViewInfo?.rows?.[0]?.value?.modality?.join(", ") ?? "N/A"}
           </Typography>
         </Box>
-
         <Box>
           <Typography sx={{ color: Colors.darkPurple, fontWeight: "600" }}>
             DOI
@@ -76,7 +106,6 @@ const MetaDataPanel: React.FC<Props> = ({ dbViewInfo, datasetDocument }) => {
             })()}
           </Typography>
         </Box>
-
         <Box>
           <Typography sx={{ color: Colors.darkPurple, fontWeight: "600" }}>
             Subjects
@@ -120,6 +149,87 @@ const MetaDataPanel: React.FC<Props> = ({ dbViewInfo, datasetDocument }) => {
                   ?.ReferencesAndLinks ?? "N/A"}
           </Typography>
         </Box>
+
+        {revs.length > 0 && (
+          <Box
+            sx={{
+              mt: 2,
+              p: 2,
+              border: `1px solid ${Colors.lightGray}`,
+              borderRadius: 1,
+            }}
+          >
+            <Typography
+              //   variant="subtitle1"
+              sx={{ mb: 1, fontWeight: 600, color: Colors.darkPurple }}
+            >
+              Revisions
+            </Typography>
+
+            <FormControl fullWidth size="small" sx={{ mb: 1 }}>
+              <InputLabel id="rev-select-label">Select revision</InputLabel>
+              <Select
+                labelId="rev-select-label"
+                label="Select revision"
+                value={revIdx}
+                onChange={(e) => setRevIdx(Number(e.target.value))}
+              >
+                {revs.map((r, idx) => (
+                  <MenuItem key={r.rev} value={idx}>
+                    <Typography
+                      component="span"
+                      sx={{ fontFamily: "monospace" }}
+                    >
+                      {r.rev.slice(0, 8)}…{r.rev.slice(-4)}
+                    </Typography>
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+
+            {selected && (
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  gap: 1,
+                }}
+              >
+                <Box sx={{ minWidth: 0 }}>
+                  <Typography variant="body2" sx={{ color: "text.secondary" }}>
+                    Selected rev:
+                  </Typography>
+                  <Typography
+                    variant="body2"
+                    sx={{ fontFamily: "monospace", wordBreak: "break-all" }}
+                    title={selected.rev}
+                  >
+                    {selected.rev}
+                  </Typography>
+                </Box>
+                <Tooltip title="Open this revision in NeuroJSON.io">
+                  <IconButton
+                    size="small"
+                    onClick={() =>
+                      window.open(
+                        `https://neurojson.io:7777/${dbName}/${docId}?rev=${selected.rev}`,
+                        "_blank"
+                      )
+                    }
+                  >
+                    <ArrowCircleRightIcon
+                      fontSize="small"
+                      sx={{
+                        color: Colors.purple,
+                      }}
+                    />
+                  </IconButton>
+                </Tooltip>
+              </Box>
+            )}
+          </Box>
+        )}
       </Box>
     </Box>
   );

--- a/src/components/DatasetDetailPage/MetaDataPanel.tsx
+++ b/src/components/DatasetDetailPage/MetaDataPanel.tsx
@@ -1,5 +1,4 @@
 import ArrowCircleRightIcon from "@mui/icons-material/ArrowCircleRight";
-import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import {
   Box,
   Typography,
@@ -42,7 +41,7 @@ const MetaDataPanel: React.FC<Props> = ({
   return (
     <Box
       sx={{
-        backgroundColor: Colors.white,
+        backgroundColor: "#fff",
         borderRadius: "8px",
         display: "flex",
         flexDirection: "column",
@@ -173,17 +172,17 @@ const MetaDataPanel: React.FC<Props> = ({
                 mb: 1,
                 "& .MuiOutlinedInput-root": {
                   "& fieldset": {
-                    borderColor: Colors.purple,
+                    borderColor: Colors.green,
                   },
                   "&:hover fieldset": {
-                    borderColor: Colors.purple,
+                    borderColor: Colors.green,
                   },
                   "&.Mui-focused fieldset": {
-                    borderColor: Colors.purple,
+                    borderColor: Colors.green,
                   },
                 },
                 "& .MuiInputLabel-root.Mui-focused": {
-                  color: Colors.purple,
+                  color: Colors.green,
                 },
               }}
             >
@@ -242,7 +241,7 @@ const MetaDataPanel: React.FC<Props> = ({
                     <ArrowCircleRightIcon
                       fontSize="small"
                       sx={{
-                        color: Colors.purple,
+                        color: Colors.green,
                       }}
                     />
                   </IconButton>

--- a/src/components/DatasetDetailPage/MetaDataPanel.tsx
+++ b/src/components/DatasetDetailPage/MetaDataPanel.tsx
@@ -1,0 +1,128 @@
+import { Box, Typography } from "@mui/material";
+import { Colors } from "design/theme";
+import React from "react";
+
+type Props = {
+  dbViewInfo: any;
+  datasetDocument: any;
+};
+
+const MetaDataPanel: React.FC<Props> = ({ dbViewInfo, datasetDocument }) => {
+  return (
+    <Box
+      sx={{
+        backgroundColor: Colors.white,
+        borderRadius: "8px",
+        display: "flex",
+        flexDirection: "column",
+        overflow: "hidden",
+        height: "100%",
+        minHeight: 0,
+      }}
+    >
+      <Box
+        sx={{
+          flex: 1,
+          minHeight: 0, // <-- for scroller
+          overflowY: "auto", // <-- keep the scroller here
+          p: 2,
+          display: "flex",
+          flexDirection: "column",
+          gap: 1,
+        }}
+      >
+        <Box>
+          <Typography sx={{ color: Colors.darkPurple, fontWeight: "600" }}>
+            Modalities
+          </Typography>
+          <Typography sx={{ color: "text.secondary" }}>
+            {dbViewInfo?.rows?.[0]?.value?.modality?.join(", ") ?? "N/A"}
+          </Typography>
+        </Box>
+
+        <Box>
+          <Typography sx={{ color: Colors.darkPurple, fontWeight: "600" }}>
+            DOI
+          </Typography>
+          <Typography sx={{ color: "text.secondary" }}>
+            {(() => {
+              const doi =
+                datasetDocument?.["dataset_description.json"]?.DatasetDOI ||
+                datasetDocument?.["dataset_description.json"]?.ReferenceDOI;
+
+              if (!doi) return "N/A";
+
+              // Normalize into a clickable URL
+              let url = doi;
+              if (/^10\./.test(doi)) {
+                url = `https://doi.org/${doi}`;
+              } else if (/^doi:/.test(doi)) {
+                url = `https://doi.org/${doi.replace(/^doi:/, "")}`;
+              }
+
+              return (
+                <a
+                  href={url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  style={{
+                    color: "inherit",
+                    textDecoration: "underline",
+                  }}
+                >
+                  {url}
+                </a>
+              );
+            })()}
+          </Typography>
+        </Box>
+
+        <Box>
+          <Typography sx={{ color: Colors.darkPurple, fontWeight: "600" }}>
+            Subjects
+          </Typography>
+          <Typography sx={{ color: "text.secondary" }}>
+            {dbViewInfo?.rows?.[0]?.value?.subj?.length ?? "N/A"}
+          </Typography>
+        </Box>
+        <Box>
+          <Typography sx={{ color: Colors.darkPurple, fontWeight: "600" }}>
+            License
+          </Typography>
+          <Typography sx={{ color: "text.secondary" }}>
+            {datasetDocument?.["dataset_description.json"]?.License ?? "N/A"}
+          </Typography>
+        </Box>
+        <Box>
+          <Typography sx={{ color: Colors.darkPurple, fontWeight: "600" }}>
+            BIDS Version
+          </Typography>
+          <Typography sx={{ color: "text.secondary" }}>
+            {datasetDocument?.["dataset_description.json"]?.BIDSVersion ??
+              "N/A"}
+          </Typography>
+        </Box>
+        <Box>
+          <Typography sx={{ color: Colors.darkPurple, fontWeight: "600" }}>
+            References and Links
+          </Typography>
+          <Typography sx={{ color: "text.secondary" }}>
+            {Array.isArray(
+              datasetDocument?.["dataset_description.json"]?.ReferencesAndLinks
+            )
+              ? datasetDocument["dataset_description.json"].ReferencesAndLinks
+                  .length > 0
+                ? datasetDocument[
+                    "dataset_description.json"
+                  ].ReferencesAndLinks.join(", ")
+                : "N/A"
+              : datasetDocument?.["dataset_description.json"]
+                  ?.ReferencesAndLinks ?? "N/A"}
+          </Typography>
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+export default MetaDataPanel;

--- a/src/components/DatasetDetailPage/MetaDataPanel.tsx
+++ b/src/components/DatasetDetailPage/MetaDataPanel.tsx
@@ -166,7 +166,27 @@ const MetaDataPanel: React.FC<Props> = ({
               Revisions
             </Typography>
 
-            <FormControl fullWidth size="small" sx={{ mb: 1 }}>
+            <FormControl
+              fullWidth
+              size="small"
+              sx={{
+                mb: 1,
+                "& .MuiOutlinedInput-root": {
+                  "& fieldset": {
+                    borderColor: Colors.purple,
+                  },
+                  "&:hover fieldset": {
+                    borderColor: Colors.purple,
+                  },
+                  "&.Mui-focused fieldset": {
+                    borderColor: Colors.purple,
+                  },
+                },
+                "& .MuiInputLabel-root.Mui-focused": {
+                  color: Colors.purple,
+                },
+              }}
+            >
               <InputLabel id="rev-select-label">Select revision</InputLabel>
               <Select
                 labelId="rev-select-label"
@@ -174,16 +194,17 @@ const MetaDataPanel: React.FC<Props> = ({
                 value={revIdx}
                 onChange={(e) => setRevIdx(Number(e.target.value))}
               >
-                {revs.map((r, idx) => (
-                  <MenuItem key={r.rev} value={idx}>
-                    <Typography
-                      component="span"
-                      sx={{ fontFamily: "monospace" }}
-                    >
-                      {r.rev.slice(0, 8)}…{r.rev.slice(-4)}
-                    </Typography>
-                  </MenuItem>
-                ))}
+                {revs.map((r, idx) => {
+                  const [verNum, hash] = r.rev.split("-", 2);
+                  return (
+                    <MenuItem key={r.rev} value={idx}>
+                      <Typography component="span">
+                        Revision {verNum} ({r.rev.slice(0, 8)}…{r.rev.slice(-4)}
+                        )
+                      </Typography>
+                    </MenuItem>
+                  );
+                })}
               </Select>
             </FormControl>
 

--- a/src/components/DatasetPageCard.tsx
+++ b/src/components/DatasetPageCard.tsx
@@ -15,6 +15,24 @@ import { useNavigate } from "react-router-dom";
 import { Row } from "redux/neurojson/types/neurojson.interface";
 import RoutesEnum from "types/routes.enum";
 
+const formatSize = (sizeInBytes: number): string => {
+  if (sizeInBytes < 1024) {
+    return `${sizeInBytes} Bytes`;
+  } else if (sizeInBytes < 1024 * 1024) {
+    return `${(sizeInBytes / 1024).toFixed(1)} KB`;
+  } else if (sizeInBytes < 1024 * 1024 * 1024) {
+    return `${(sizeInBytes / (1024 * 1024)).toFixed(2)} MB`;
+  } else if (sizeInBytes < 1024 * 1024 * 1024 * 1024) {
+    return `${(sizeInBytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+  } else {
+    return `${(sizeInBytes / (1024 * 1024 * 1024 * 1024)).toFixed(2)} TB`;
+  }
+};
+
+// for showing the size
+const jsonBytes = (obj: unknown) =>
+  obj ? new TextEncoder().encode(JSON.stringify(obj)).length : 0;
+
 interface DatasetPageCardProps {
   doc: Row;
   index: number;
@@ -32,6 +50,11 @@ const DatasetPageCard: React.FC<DatasetPageCardProps> = ({
 }) => {
   const navigate = useNavigate();
   const datasetIndex = (page - 1) * pageSize + index + 1;
+  const sizeInBytes = React.useMemo(() => {
+    const len = (doc as any)?.value?.length; // bytes from backend (full doc)
+    if (typeof len === "number" && Number.isFinite(len)) return len;
+    return jsonBytes(doc.value); // fallback: summary object size
+  }, [doc.value]);
   return (
     <Grid item xs={12} sm={6} key={doc.id}>
       <Card
@@ -133,9 +156,10 @@ const DatasetPageCard: React.FC<DatasetPageCardProps> = ({
             <Stack direction="row" spacing={2} alignItems="center">
               <Typography variant="body2" color={Colors.textPrimary}>
                 <strong>Size:</strong>{" "}
-                {doc.value.length
+                {/* {doc.value.length
                   ? `${(doc.value.length / 1024 / 1024).toFixed(2)} MB`
-                  : "Unknown"}
+                  : "Unknown"} */}
+                {formatSize(sizeInBytes)}
               </Typography>
 
               {doc.value.info?.DatasetDOI && (

--- a/src/components/DatasetPageCard.tsx
+++ b/src/components/DatasetPageCard.tsx
@@ -51,7 +51,7 @@ const DatasetPageCard: React.FC<DatasetPageCardProps> = ({
   const navigate = useNavigate();
   const datasetIndex = (page - 1) * pageSize + index + 1;
   const sizeInBytes = React.useMemo(() => {
-    const len = (doc as any)?.value?.length; // bytes from backend (full doc)
+    const len = (doc as any)?.value?.length; // bytes from length key
     if (typeof len === "number" && Number.isFinite(len)) return len;
     return jsonBytes(doc.value); // fallback: summary object size
   }, [doc.value]);

--- a/src/components/SearchPage/DatabaseCard.tsx
+++ b/src/components/SearchPage/DatabaseCard.tsx
@@ -1,0 +1,166 @@
+import {
+  Box,
+  Typography,
+  Chip,
+  Card,
+  CardContent,
+  Stack,
+  Avatar,
+} from "@mui/material";
+import { Colors } from "design/theme";
+import React from "react";
+import { Link } from "react-router-dom";
+import RoutesEnum from "types/routes.enum";
+
+type Props = {
+  dbName?: string;
+  fullName?: string;
+  datasets?: number;
+  modalities?: string[];
+  logo?: string;
+  keyword?: string;
+  onChipClick: (key: string, value: string) => void;
+};
+
+const DatabaseCard: React.FC<Props> = ({
+  dbName,
+  fullName,
+  datasets,
+  modalities,
+  logo,
+  keyword,
+  onChipClick,
+}) => {
+  const databaseLink = `${RoutesEnum.DATABASES}/${dbName}`;
+  // keyword hightlight functional component
+  const highlightKeyword = (text: string, keyword?: string) => {
+    if (!keyword || !text?.toLowerCase().includes(keyword.toLowerCase())) {
+      return text;
+    }
+
+    const regex = new RegExp(`(${keyword})`, "gi"); // for case-insensitive and global
+    const parts = text.split(regex);
+
+    return (
+      <>
+        {parts.map((part, i) =>
+          part.toLowerCase() === keyword.toLowerCase() ? (
+            <mark
+              key={i}
+              style={{ backgroundColor: "yellow", fontWeight: 600 }}
+            >
+              {part}
+            </mark>
+          ) : (
+            <React.Fragment key={i}>{part}</React.Fragment>
+          )
+        )}
+      </>
+    );
+  };
+
+  return (
+    <Card sx={{ mb: 3, position: "relative" }}>
+      <CardContent>
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "row",
+            alignItems: "center",
+            justifyContent: "flex-start",
+            gap: 2,
+          }}
+        >
+          {/* Logo as Avatar */}
+          <Box sx={{ display: "flex", alignItems: "center" }}>
+            {logo && (
+              <Avatar
+                variant="square"
+                src={logo}
+                alt={fullName || "Database Logo"}
+                sx={{
+                  width: 60,
+                  height: 60,
+                  mb: 1,
+                  "& img": {
+                    objectFit: "contain", // show full image inside
+                  },
+                }}
+              />
+            )}
+          </Box>
+          {/* database card */}
+          <Box>
+            <Typography
+              variant="h6"
+              sx={{
+                fontWeight: 600,
+                color: Colors.darkPurple,
+                textDecoration: "none",
+                ":hover": { textDecoration: "underline" },
+              }}
+              component={Link}
+              to={databaseLink}
+              target="_blank"
+            >
+              Database:{" "}
+              {highlightKeyword(fullName || "Untitled Database", keyword)}
+            </Typography>
+            <Stack spacing={2} margin={1}>
+              <Stack
+                direction="row"
+                spacing={1}
+                flexWrap="wrap"
+                gap={1}
+                alignItems="center"
+              >
+                <Typography variant="body2" mt={1}>
+                  <strong>Modalities:</strong>
+                </Typography>
+
+                {Array.isArray(modalities) && modalities.length > 0 ? (
+                  modalities.map((mod, idx) => (
+                    <Chip
+                      key={idx}
+                      label={mod}
+                      variant="outlined"
+                      onClick={() => onChipClick("modality", mod)}
+                      sx={{
+                        "& .MuiChip-label": {
+                          paddingX: "6px",
+                          fontSize: "0.8rem",
+                        },
+                        height: "24px",
+                        color: Colors.darkPurple,
+                        border: `1px solid ${Colors.darkPurple}`,
+                        fontWeight: "bold",
+                        transition: "all 0.2s ease",
+                        "&:hover": {
+                          backgroundColor: `${Colors.purple} !important`,
+                          color: "white",
+                          borderColor: Colors.purple,
+                        },
+                      }}
+                    />
+                  ))
+                ) : (
+                  <Typography variant="body2" mt={1}>
+                    N/A
+                  </Typography>
+                )}
+              </Stack>
+
+              <Stack direction="row" spacing={1} flexWrap="wrap" gap={1}>
+                <Typography variant="body2" mt={1}>
+                  <strong>Datasets:</strong> {datasets ?? "N/A"}
+                </Typography>
+              </Stack>
+            </Stack>
+          </Box>
+        </Box>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default DatabaseCard;

--- a/src/components/SearchPage/DatabaseCard.tsx
+++ b/src/components/SearchPage/DatabaseCard.tsx
@@ -11,6 +11,7 @@ import { Colors } from "design/theme";
 import React from "react";
 import { Link } from "react-router-dom";
 import RoutesEnum from "types/routes.enum";
+import { modalityValueToEnumLabel } from "utils/SearchPageFunctions/modalityLabels";
 
 type Props = {
   dbName?: string;
@@ -56,6 +57,47 @@ const DatabaseCard: React.FC<Props> = ({
           )
         )}
       </>
+    );
+  };
+
+  // for datatype rendering
+  const isClickableModality = (raw: string) =>
+    !!modalityValueToEnumLabel[raw.toLowerCase()];
+
+  const renderDatatype = (raw: string, idx: number) => {
+    const key = raw.toLowerCase();
+    const label = modalityValueToEnumLabel[key];
+
+    if (label) {
+      // Clickable modality → drives the "modality" filter
+      return (
+        <Chip
+          key={`${key}-${idx}`}
+          label={key}
+          variant="outlined"
+          onClick={() => onChipClick("modality", key)} // pass normalized key
+          sx={{
+            "& .MuiChip-label": { px: "6px", fontSize: "0.8rem" },
+            height: 24,
+            color: Colors.darkPurple,
+            border: `1px solid ${Colors.darkPurple}`,
+            fontWeight: "bold",
+            transition: "all 0.2s ease",
+            "&:hover": {
+              backgroundColor: `${Colors.purple} !important`,
+              color: "white",
+              borderColor: Colors.purple,
+            },
+          }}
+        />
+      );
+    }
+
+    // Not a modality → render as plain text (or a disabled/outlined chip if you prefer)
+    return (
+      <Typography key={`${key}-${idx}`} variant="body2" sx={{ mt: 1, mr: 1 }}>
+        {raw}
+      </Typography>
     );
   };
 
@@ -115,35 +157,38 @@ const DatabaseCard: React.FC<Props> = ({
                 alignItems="center"
               >
                 <Typography variant="body2" mt={1}>
-                  <strong>Modalities:</strong>
+                  <strong>Data Type:</strong>
                 </Typography>
 
                 {Array.isArray(modalities) && modalities.length > 0 ? (
-                  modalities.map((mod, idx) => (
-                    <Chip
-                      key={idx}
-                      label={mod}
-                      variant="outlined"
-                      onClick={() => onChipClick("modality", mod)}
-                      sx={{
-                        "& .MuiChip-label": {
-                          paddingX: "6px",
-                          fontSize: "0.8rem",
-                        },
-                        height: "24px",
-                        color: Colors.darkPurple,
-                        border: `1px solid ${Colors.darkPurple}`,
-                        fontWeight: "bold",
-                        transition: "all 0.2s ease",
-                        "&:hover": {
-                          backgroundColor: `${Colors.purple} !important`,
-                          color: "white",
-                          borderColor: Colors.purple,
-                        },
-                      }}
-                    />
-                  ))
+                  modalities.map(renderDatatype)
                 ) : (
+                  // (
+                  //   modalities.map((mod, idx) => (
+                  //     <Chip
+                  //       key={idx}
+                  //       label={mod}
+                  //       variant="outlined"
+                  //       onClick={() => onChipClick("modality", mod)}
+                  //       sx={{
+                  //         "& .MuiChip-label": {
+                  //           paddingX: "6px",
+                  //           fontSize: "0.8rem",
+                  //         },
+                  //         height: "24px",
+                  //         color: Colors.darkPurple,
+                  //         border: `1px solid ${Colors.darkPurple}`,
+                  //         fontWeight: "bold",
+                  //         transition: "all 0.2s ease",
+                  //         "&:hover": {
+                  //           backgroundColor: `${Colors.purple} !important`,
+                  //           color: "white",
+                  //           borderColor: Colors.purple,
+                  //         },
+                  //       }}
+                  //     />
+                  //   ))
+                  // )
                   <Typography variant="body2" mt={1}>
                     N/A
                   </Typography>

--- a/src/components/SearchPage/DatabaseCard.tsx
+++ b/src/components/SearchPage/DatabaseCard.tsx
@@ -14,7 +14,7 @@ import RoutesEnum from "types/routes.enum";
 import { modalityValueToEnumLabel } from "utils/SearchPageFunctions/modalityLabels";
 
 type Props = {
-  dbName?: string;
+  dbId?: string;
   fullName?: string;
   datasets?: number;
   modalities?: string[];
@@ -24,7 +24,7 @@ type Props = {
 };
 
 const DatabaseCard: React.FC<Props> = ({
-  dbName,
+  dbId,
   fullName,
   datasets,
   modalities,
@@ -32,7 +32,7 @@ const DatabaseCard: React.FC<Props> = ({
   keyword,
   onChipClick,
 }) => {
-  const databaseLink = `${RoutesEnum.DATABASES}/${dbName}`;
+  const databaseLink = `${RoutesEnum.DATABASES}/${dbId}`;
   // keyword hightlight functional component
   const highlightKeyword = (text: string, keyword?: string) => {
     if (!keyword || !text?.toLowerCase().includes(keyword.toLowerCase())) {

--- a/src/pages/DatasetPage.tsx
+++ b/src/pages/DatasetPage.tsx
@@ -39,6 +39,20 @@ const DatasetPage: React.FC = () => {
   const totalPages = Math.ceil(limit / pageSize);
   const [searchQuery, setSearchQuery] = useState("");
 
+  const formatSize = (sizeInBytes: number): string => {
+    if (sizeInBytes < 1024) {
+      return `${sizeInBytes} Bytes`;
+    } else if (sizeInBytes < 1024 * 1024) {
+      return `${(sizeInBytes / 1024).toFixed(1)} KB`;
+    } else if (sizeInBytes < 1024 * 1024 * 1024) {
+      return `${(sizeInBytes / (1024 * 1024)).toFixed(2)} MB`;
+    } else if (sizeInBytes < 1024 * 1024 * 1024 * 1024) {
+      return `${(sizeInBytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+    } else {
+      return `${(sizeInBytes / (1024 * 1024 * 1024 * 1024)).toFixed(2)} TB`;
+    }
+  };
+
   useEffect(() => {
     if (dbName) {
       dispatch(fetchDbInfo(dbName.toLowerCase()));
@@ -326,11 +340,12 @@ const DatasetPage: React.FC = () => {
         <Grid container spacing={3}>
           {filteredData.map((doc: any, index: number) => {
             const datasetIndex = (currentPage - 1) * pageSize + index + 1;
+
             return (
               <Grid item xs={12} sm={6} key={doc.id}>
                 <Card
                   sx={{
-                    position: "relative", // ✅ allows absolute positioning of the number
+                    position: "relative", // allows absolute positioning of the number
                     backgroundColor: Colors.white,
                     boxShadow: "0 2px 4px rgba(0,0,0,0.1)",
                     height: "100%",

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -408,7 +408,7 @@ const SearchPage: React.FC = () => {
               p: 3,
               borderRadius: 2,
               boxShadow: 1,
-              minWidth: "35%",
+              minWidth: "25%",
             }}
           >
             {renderFilterForm()}
@@ -510,162 +510,187 @@ const SearchPage: React.FC = () => {
             </Box>
           )}
 
-          {/* matching databases */}
-          {keywordInput && registryMatches.length > 0 && (
-            <Box sx={{ mb: 3 }}>
-              <Typography
-                variant="h6"
-                sx={{ mb: 1.5, mt: 1.5, fontWeight: "600" }}
+          <Box
+            sx={{
+              display: "grid",
+              gridTemplateColumns: {
+                xs: "1fr",
+                md: hasDbMatches ? "1fr 2fr" : "1fr",
+              },
+              gap: 2,
+              alignItems: "baseline",
+            }}
+          >
+            {/* matching databases */}
+            {keywordInput && registryMatches.length > 0 && (
+              <Box
+                sx={{
+                  mb: 3,
+                  borderRight: `2px solid ${Colors.lightGray}`,
+                  pr: 2,
+                }}
               >
-                Matching Databases
-              </Typography>
-              {registryMatches.map((db) => (
-                <DatabaseCard
-                  key={db.id}
-                  dbName={db.name}
-                  fullName={db.fullname}
-                  datasets={db.datasets}
-                  modalities={db.datatype}
-                  logo={db.logo}
-                  keyword={formData.keyword} // for keyword highlight
-                  onChipClick={handleChipClick}
-                />
-              ))}
-            </Box>
-          )}
+                <Typography
+                  variant="h6"
+                  sx={{
+                    mb: 1.5,
+                    mt: 1.5,
+                    borderBottom: "1px solid lightgray",
+                  }}
+                >
+                  Matching Databases
+                </Typography>
+                {registryMatches.map((db) => (
+                  <DatabaseCard
+                    key={db.id}
+                    dbName={db.name}
+                    fullName={db.fullname}
+                    datasets={db.datasets}
+                    modalities={db.datatype}
+                    logo={db.logo}
+                    keyword={formData.keyword} // for keyword highlight
+                    onChipClick={handleChipClick}
+                  />
+                ))}
+              </Box>
+            )}
 
-          {/* results */}
-          {hasSearched && (
-            <Box mt={4}>
-              {loading ? (
-                <Box textAlign="center" my={4}>
-                  <CircularProgress />
-                  <Typography mt={2} color="text.secondary">
-                    Loading search results...
-                  </Typography>
-                </Box>
-              ) : (
-                <>
-                  {/* Only show header when there are dataset hits */}
-                  {hasDatasetMatches && (
-                    <Typography
-                      variant="h6"
-                      sx={{ borderBottom: "1px solid lightgray", mb: 2 }}
-                    >
-                      {`Showing ${results.length} ${
-                        isDataset ? "Datasets" : "Subjects"
-                      }`}
+            {/* results */}
+            {hasSearched && (
+              <Box mt={4}>
+                {loading ? (
+                  <Box textAlign="center" my={4}>
+                    <CircularProgress />
+                    <Typography mt={2} color="text.secondary">
+                      Loading search results...
                     </Typography>
-                  )}
-
-                  {/* pagination + cards (unchanged, but guard with hasDatasetMatches) */}
-                  {hasDatasetMatches && (
-                    <>
-                      {results.length >= 50 && (
-                        <Box textAlign="center" mt={2}>
-                          <Button
-                            variant="outlined"
-                            onClick={handleLoadMore}
-                            sx={{
-                              color: Colors.purple,
-                              borderColor: Colors.purple,
-                              "&:hover": {
-                                transform: "scale(1.05)",
-                                borderColor: Colors.purple,
-                              },
-                            }}
-                          >
-                            Load Extra 50 Results
-                          </Button>
-                        </Box>
-                      )}
-
-                      <Box textAlign="center" mt={2} mb={2}>
-                        <Pagination
-                          count={Math.ceil(results.length / itemsPerPage)}
-                          page={page}
-                          onChange={handlePageChange}
-                          showFirstButton
-                          showLastButton
-                          siblingCount={2}
-                          sx={{
-                            "& .MuiPagination-ul": { justifyContent: "center" },
-                            "& .MuiPaginationItem-root": {
-                              color: Colors.darkPurple,
-                            },
-                            "& .MuiPaginationItem-root.Mui-selected": {
-                              backgroundColor: Colors.purple,
-                              color: "white",
-                              fontWeight: "bold",
-                              "&:hover": {
-                                backgroundColor: Colors.secondaryPurple,
-                              },
-                            },
-                          }}
-                        />
-                      </Box>
-
-                      {results.length > 0 &&
-                        paginatedResults.length > 0 &&
-                        paginatedResults.map((item, idx) => {
-                          try {
-                            const parsedJson = JSON.parse(item.json);
-                            const globalIndex = (page - 1) * itemsPerPage + idx;
-
-                            const isDataset =
-                              parsedJson?.value?.subj &&
-                              Array.isArray(parsedJson.value.subj);
-
-                            return isDataset ? (
-                              <DatasetCard
-                                key={idx}
-                                index={globalIndex}
-                                dbname={item.dbname}
-                                dsname={item.dsname}
-                                parsedJson={parsedJson}
-                                onChipClick={handleChipClick}
-                                keyword={formData.keyword} // for keyword highlight
-                              />
-                            ) : (
-                              <SubjectCard
-                                key={idx}
-                                index={globalIndex}
-                                {...item}
-                                parsedJson={parsedJson}
-                                onChipClick={handleChipClick}
-                              />
-                            );
-                          } catch (e) {
-                            console.error(
-                              `Failed to parse JSON for item #${idx}`,
-                              e
-                            );
-                            return null;
-                          }
-                        })}
-                    </>
-                  )}
-
-                  {/* Single place to show the red message */}
-                  {showNoResults && (
-                    <Typography sx={{ color: Colors.error }}>
-                      No results found based on your criteria. Please adjust the
-                      filters and try again.
-                    </Typography>
-                  )}
-
-                  {hasSearched &&
-                    !loading &&
-                    !Array.isArray(results) &&
-                    results?.msg !== "empty output" && (
-                      <Typography sx={{ color: Colors.error }}>
-                        Something went wrong. Please try again later.
+                  </Box>
+                ) : (
+                  <>
+                    {/* Only show header when there are dataset hits */}
+                    {hasDatasetMatches && (
+                      <Typography
+                        variant="h6"
+                        sx={{ borderBottom: "1px solid lightgray", mb: 2 }}
+                      >
+                        {`Showing ${results.length} ${
+                          isDataset ? "Datasets" : "Subjects"
+                        }`}
                       </Typography>
                     )}
-                </>
-              )}
-            </Box>
-          )}
+
+                    {/* pagination + cards (unchanged, but guard with hasDatasetMatches) */}
+                    {hasDatasetMatches && (
+                      <>
+                        {results.length >= 50 && (
+                          <Box textAlign="center" mt={2}>
+                            <Button
+                              variant="outlined"
+                              onClick={handleLoadMore}
+                              sx={{
+                                color: Colors.purple,
+                                borderColor: Colors.purple,
+                                "&:hover": {
+                                  transform: "scale(1.05)",
+                                  borderColor: Colors.purple,
+                                },
+                              }}
+                            >
+                              Load Extra 50 Results
+                            </Button>
+                          </Box>
+                        )}
+
+                        <Box textAlign="center" mt={2} mb={2}>
+                          <Pagination
+                            count={Math.ceil(results.length / itemsPerPage)}
+                            page={page}
+                            onChange={handlePageChange}
+                            showFirstButton
+                            showLastButton
+                            siblingCount={2}
+                            sx={{
+                              "& .MuiPagination-ul": {
+                                justifyContent: "center",
+                              },
+                              "& .MuiPaginationItem-root": {
+                                color: Colors.darkPurple,
+                              },
+                              "& .MuiPaginationItem-root.Mui-selected": {
+                                backgroundColor: Colors.purple,
+                                color: "white",
+                                fontWeight: "bold",
+                                "&:hover": {
+                                  backgroundColor: Colors.secondaryPurple,
+                                },
+                              },
+                            }}
+                          />
+                        </Box>
+
+                        {results.length > 0 &&
+                          paginatedResults.length > 0 &&
+                          paginatedResults.map((item, idx) => {
+                            try {
+                              const parsedJson = JSON.parse(item.json);
+                              const globalIndex =
+                                (page - 1) * itemsPerPage + idx;
+
+                              const isDataset =
+                                parsedJson?.value?.subj &&
+                                Array.isArray(parsedJson.value.subj);
+
+                              return isDataset ? (
+                                <DatasetCard
+                                  key={idx}
+                                  index={globalIndex}
+                                  dbname={item.dbname}
+                                  dsname={item.dsname}
+                                  parsedJson={parsedJson}
+                                  onChipClick={handleChipClick}
+                                  keyword={formData.keyword} // for keyword highlight
+                                />
+                              ) : (
+                                <SubjectCard
+                                  key={idx}
+                                  index={globalIndex}
+                                  {...item}
+                                  parsedJson={parsedJson}
+                                  onChipClick={handleChipClick}
+                                />
+                              );
+                            } catch (e) {
+                              console.error(
+                                `Failed to parse JSON for item #${idx}`,
+                                e
+                              );
+                              return null;
+                            }
+                          })}
+                      </>
+                    )}
+
+                    {/* Single place to show the red message */}
+                    {showNoResults && (
+                      <Typography sx={{ color: Colors.error }}>
+                        No results found based on your criteria. Please adjust
+                        the filters and try again.
+                      </Typography>
+                    )}
+
+                    {hasSearched &&
+                      !loading &&
+                      !Array.isArray(results) &&
+                      results?.msg !== "empty output" && (
+                        <Typography sx={{ color: Colors.error }}>
+                          Something went wrong. Please try again later.
+                        </Typography>
+                      )}
+                  </>
+                )}
+              </Box>
+            )}
+          </Box>
 
           {/* {hasSearched && (
             <Box mt={4}>

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -327,6 +327,19 @@ const SearchPage: React.FC = () => {
     </>
   );
 
+  // check if has database/dataset matches
+  const hasDbMatches = !!keywordInput && registryMatches.length > 0;
+  const hasDatasetMatches = Array.isArray(results) && results.length > 0;
+  // when backend find nothing
+  const backendEmpty =
+    !Array.isArray(results) && (results as any)?.msg === "empty output";
+
+  // show red message only if nothing matched at all
+  const showNoResults =
+    hasSearched &&
+    !loading &&
+    !hasDbMatches &&
+    (!hasDatasetMatches || backendEmpty);
   return (
     <Container
       maxWidth={false}
@@ -414,8 +427,8 @@ const SearchPage: React.FC = () => {
                 color: Colors.darkPurple,
               }}
             >
-              Use the filters to search for datasets or subjects based on
-              metadata.
+              Use the filters and click submit to search for datasets or
+              subjects based on metadata.
             </Typography>
           )}
         </Box>
@@ -523,6 +536,138 @@ const SearchPage: React.FC = () => {
 
           {/* results */}
           {hasSearched && (
+            <Box mt={4}>
+              {loading ? (
+                <Box textAlign="center" my={4}>
+                  <CircularProgress />
+                  <Typography mt={2} color="text.secondary">
+                    Loading search results...
+                  </Typography>
+                </Box>
+              ) : (
+                <>
+                  {/* Only show header when there are dataset hits */}
+                  {hasDatasetMatches && (
+                    <Typography
+                      variant="h6"
+                      sx={{ borderBottom: "1px solid lightgray", mb: 2 }}
+                    >
+                      {`Showing ${results.length} ${
+                        isDataset ? "Datasets" : "Subjects"
+                      }`}
+                    </Typography>
+                  )}
+
+                  {/* pagination + cards (unchanged, but guard with hasDatasetMatches) */}
+                  {hasDatasetMatches && (
+                    <>
+                      {results.length >= 50 && (
+                        <Box textAlign="center" mt={2}>
+                          <Button
+                            variant="outlined"
+                            onClick={handleLoadMore}
+                            sx={{
+                              color: Colors.purple,
+                              borderColor: Colors.purple,
+                              "&:hover": {
+                                transform: "scale(1.05)",
+                                borderColor: Colors.purple,
+                              },
+                            }}
+                          >
+                            Load Extra 50 Results
+                          </Button>
+                        </Box>
+                      )}
+
+                      <Box textAlign="center" mt={2} mb={2}>
+                        <Pagination
+                          count={Math.ceil(results.length / itemsPerPage)}
+                          page={page}
+                          onChange={handlePageChange}
+                          showFirstButton
+                          showLastButton
+                          siblingCount={2}
+                          sx={{
+                            "& .MuiPagination-ul": { justifyContent: "center" },
+                            "& .MuiPaginationItem-root": {
+                              color: Colors.darkPurple,
+                            },
+                            "& .MuiPaginationItem-root.Mui-selected": {
+                              backgroundColor: Colors.purple,
+                              color: "white",
+                              fontWeight: "bold",
+                              "&:hover": {
+                                backgroundColor: Colors.secondaryPurple,
+                              },
+                            },
+                          }}
+                        />
+                      </Box>
+
+                      {results.length > 0 &&
+                        paginatedResults.length > 0 &&
+                        paginatedResults.map((item, idx) => {
+                          try {
+                            const parsedJson = JSON.parse(item.json);
+                            const globalIndex = (page - 1) * itemsPerPage + idx;
+
+                            const isDataset =
+                              parsedJson?.value?.subj &&
+                              Array.isArray(parsedJson.value.subj);
+
+                            return isDataset ? (
+                              <DatasetCard
+                                key={idx}
+                                index={globalIndex}
+                                dbname={item.dbname}
+                                dsname={item.dsname}
+                                parsedJson={parsedJson}
+                                onChipClick={handleChipClick}
+                                keyword={formData.keyword} // for keyword highlight
+                              />
+                            ) : (
+                              <SubjectCard
+                                key={idx}
+                                index={globalIndex}
+                                {...item}
+                                parsedJson={parsedJson}
+                                onChipClick={handleChipClick}
+                              />
+                            );
+                          } catch (e) {
+                            console.error(
+                              `Failed to parse JSON for item #${idx}`,
+                              e
+                            );
+                            return null;
+                          }
+                        })}
+                    </>
+                  )}
+
+                  {/* Single place to show the red message */}
+                  {showNoResults && (
+                    <Typography sx={{ color: Colors.error }}>
+                      No results found based on your criteria. Please adjust the
+                      filters and try again.
+                    </Typography>
+                  )}
+
+                  {hasSearched &&
+                    !loading &&
+                    !Array.isArray(results) &&
+                    results?.msg !== "empty output" && (
+                      <Typography sx={{ color: Colors.error }}>
+                        Something went wrong. Please try again later.
+                      </Typography>
+                    )}
+                </>
+              )}
+            </Box>
+          )}
+
+          {/* {hasSearched && (
             <Box mt={4}>
               {loading ? (
                 <Box textAlign="center" my={4}>
@@ -640,7 +785,7 @@ const SearchPage: React.FC = () => {
                 </Typography>
               )}
             </Box>
-          )}
+          )} */}
         </Box>
 
         {/* mobile version filters */}

--- a/src/pages/UpdatedDatasetDetailPage.tsx
+++ b/src/pages/UpdatedDatasetDetailPage.tsx
@@ -272,10 +272,16 @@ const UpdatedDatasetDetailPage: React.FC = () => {
           index, // Assign index correctly
         })
       );
-      const bytes = new TextEncoder().encode(
-        JSON.stringify(datasetDocument)
-      ).length;
-      setJsonSize(bytes);
+
+      const bytes = new Blob([JSON.stringify(datasetDocument)], {
+        type: "application/json",
+      });
+      setJsonSize(bytes.size);
+
+      //   const bytes = new TextEncoder().encode(
+      //     JSON.stringify(datasetDocument)
+      //   ).length;
+      //   setJsonSize(bytes);
       // Extract Internal Data & Assign `index`
       const internalData = extractInternalData(datasetDocument).map(
         (data, index) => ({

--- a/src/pages/UpdatedDatasetDetailPage.tsx
+++ b/src/pages/UpdatedDatasetDetailPage.tsx
@@ -937,12 +937,15 @@ const UpdatedDatasetDetailPage: React.FC = () => {
                         variant="contained"
                         size="small"
                         sx={{
-                          backgroundColor: "#1976d2",
+                          backgroundColor: Colors.purple,
                           flexShrink: 0,
                           minWidth: "70px",
                           fontSize: "0.7rem",
                           padding: "2px 6px",
                           lineHeight: 1,
+                          "&:hover": {
+                            backgroundColor: Colors.secondaryPurple,
+                          },
                         }}
                         onClick={() =>
                           handlePreview(link.data, link.index, true)
@@ -962,7 +965,7 @@ const UpdatedDatasetDetailPage: React.FC = () => {
           </Box>
           <Box
             sx={{
-              backgroundColor: "#eaeaea",
+              backgroundColor: Colors.lightBlue,
               padding: 2,
               borderRadius: "8px",
               flex: 1,
@@ -1047,11 +1050,14 @@ const UpdatedDatasetDetailPage: React.FC = () => {
                             variant="contained"
                             size="small"
                             sx={{
-                              backgroundColor: "#1976d2",
+                              backgroundColor: Colors.purple,
                               minWidth: "70px",
                               fontSize: "0.7rem",
                               padding: "2px 6px",
                               lineHeight: 1,
+                              "&:hover": {
+                                backgroundColor: Colors.secondaryPurple,
+                              },
                             }}
                             onClick={() => window.open(link.url, "_blank")}
                           >
@@ -1062,10 +1068,16 @@ const UpdatedDatasetDetailPage: React.FC = () => {
                               variant="outlined"
                               size="small"
                               sx={{
+                                color: Colors.purple,
+                                borderColor: Colors.purple,
                                 minWidth: "65px",
                                 fontSize: "0.7rem",
                                 padding: "2px 6px",
                                 lineHeight: 1,
+                                "&:hover": {
+                                  color: Colors.secondaryPurple,
+                                  borderColor: Colors.secondaryPurple,
+                                },
                               }}
                               onClick={() =>
                                 handlePreview(link.url, link.index, false)

--- a/src/pages/UpdatedDatasetDetailPage.tsx
+++ b/src/pages/UpdatedDatasetDetailPage.tsx
@@ -20,6 +20,7 @@ import {
   makeLinkMap,
 } from "components/DatasetDetailPage/FileTree/utils";
 import LoadDatasetTabs from "components/DatasetDetailPage/LoadDatasetTabs";
+import MetaDataPanel from "components/DatasetDetailPage/MetaDataPanel";
 import ReadMoreText from "design/ReadMoreText";
 import { Colors } from "design/theme";
 import { useAppDispatch } from "hooks/useAppDispatch";
@@ -73,6 +74,17 @@ const UpdatedDatasetDetailPage: React.FC = () => {
   const [previewIndex, setPreviewIndex] = useState<number>(0);
   const aiSummary = datasetDocument?.[".datainfo"]?.AISummary ?? "";
 
+  useEffect(() => {
+    if (!datasetDocument) {
+      setJsonSize(0);
+      return;
+    }
+    const bytes = new TextEncoder().encode(
+      JSON.stringify(datasetDocument)
+    ).length;
+    setJsonSize(bytes);
+  }, [datasetDocument]);
+
   // 1) detect subjects at the top level, return true or false
   const hasTopLevelSubjects = useMemo(
     () => Object.keys(datasetDocument || {}).some((k) => /^sub-/i.test(k)),
@@ -87,22 +99,22 @@ const UpdatedDatasetDetailPage: React.FC = () => {
   );
 
   // “rest” JSON only when we actually have subjects
-  const rest = useMemo(() => {
-    if (!datasetDocument || !hasTopLevelSubjects) return {};
-    const r: any = {};
-    Object.keys(datasetDocument).forEach((k) => {
-      if (!/^sub-/i.test(k)) r[k] = (datasetDocument as any)[k];
-    });
-    return r;
-  }, [datasetDocument, hasTopLevelSubjects]);
+  //   const rest = useMemo(() => {
+  //     if (!datasetDocument || !hasTopLevelSubjects) return {};
+  //     const r: any = {};
+  //     Object.keys(datasetDocument).forEach((k) => {
+  //       if (!/^sub-/i.test(k)) r[k] = (datasetDocument as any)[k];
+  //     });
+  //     return r;
+  //   }, [datasetDocument, hasTopLevelSubjects]);
 
   // JSON panel should always render:
   // - if we have subjects -> JSON show "rest" (everything except sub-*)
   // - if we don't have subjects -> JSON show the whole document
-  const jsonPanelData = useMemo(
-    () => (hasTopLevelSubjects ? rest : datasetDocument || {}),
-    [hasTopLevelSubjects, rest, datasetDocument]
-  );
+  //   const jsonPanelData = useMemo(
+  //     () => (hasTopLevelSubjects ? rest : datasetDocument || {}),
+  //     [hasTopLevelSubjects, rest, datasetDocument]
+  //   );
 
   // 5) header title + counts also fall back
   //   const treeTitle = hasTopLevelSubjects ? "Subjects" : "Files";
@@ -317,10 +329,10 @@ const UpdatedDatasetDetailPage: React.FC = () => {
         }
       });
 
-      const blob = new Blob([JSON.stringify(datasetDocument, null, 2)], {
-        type: "application/json",
-      });
-      setJsonSize(blob.size);
+      //   const blob = new Blob([JSON.stringify(datasetDocument, null, 2)], {
+      //     type: "application/json",
+      //   });
+      //   setJsonSize(blob.size);
 
       //  Construct download script dynamically
       let script = `curl -L --create-dirs "https://neurojson.io:7777/${dbName}/${docId}" -o "${docId}.json"\n`;
@@ -856,137 +868,10 @@ const UpdatedDatasetDetailPage: React.FC = () => {
               flexDirection: "column",
             }}
           >
-            <Box
-              sx={{
-                backgroundColor: Colors.white,
-                borderRadius: "8px",
-                display: "flex",
-                flexDirection: "column",
-                overflow: "hidden",
-                height: "100%",
-                minHeight: 0,
-              }}
-            >
-              <Box
-                sx={{
-                  flex: 1,
-                  minHeight: 0, // <-- for scroller
-                  overflowY: "auto", // <-- keep the scroller here
-                  p: 2,
-                  display: "flex",
-                  flexDirection: "column",
-                  gap: 1,
-                }}
-              >
-                <Box>
-                  <Typography
-                    sx={{ color: Colors.darkPurple, fontWeight: "600" }}
-                  >
-                    Modalities
-                  </Typography>
-                  <Typography sx={{ color: "text.secondary" }}>
-                    {dbViewInfo?.rows?.[0]?.value?.modality?.join(", ") ??
-                      "N/A"}
-                  </Typography>
-                </Box>
-
-                <Box>
-                  <Typography
-                    sx={{ color: Colors.darkPurple, fontWeight: "600" }}
-                  >
-                    DOI
-                  </Typography>
-                  <Typography sx={{ color: "text.secondary" }}>
-                    {(() => {
-                      const doi =
-                        datasetDocument?.["dataset_description.json"]
-                          ?.DatasetDOI ||
-                        datasetDocument?.["dataset_description.json"]
-                          ?.ReferenceDOI;
-
-                      if (!doi) return "N/A";
-
-                      // Normalize into a clickable URL
-                      let url = doi;
-                      if (/^10\./.test(doi)) {
-                        url = `https://doi.org/${doi}`;
-                      } else if (/^doi:/.test(doi)) {
-                        url = `https://doi.org/${doi.replace(/^doi:/, "")}`;
-                      }
-
-                      return (
-                        <a
-                          href={url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          style={{
-                            color: "inherit",
-                            textDecoration: "underline",
-                          }}
-                        >
-                          {url}
-                        </a>
-                      );
-                    })()}
-                  </Typography>
-                </Box>
-
-                <Box>
-                  <Typography
-                    sx={{ color: Colors.darkPurple, fontWeight: "600" }}
-                  >
-                    Subjects
-                  </Typography>
-                  <Typography sx={{ color: "text.secondary" }}>
-                    {datasetDocument?.["participants.tsv"]?.["participant_id"]
-                      ?.length ?? "N/A"}
-                  </Typography>
-                </Box>
-                <Box>
-                  <Typography
-                    sx={{ color: Colors.darkPurple, fontWeight: "600" }}
-                  >
-                    License
-                  </Typography>
-                  <Typography sx={{ color: "text.secondary" }}>
-                    {datasetDocument?.["dataset_description.json"]?.License ??
-                      "N/A"}
-                  </Typography>
-                </Box>
-                <Box>
-                  <Typography
-                    sx={{ color: Colors.darkPurple, fontWeight: "600" }}
-                  >
-                    BIDS Version
-                  </Typography>
-                  <Typography sx={{ color: "text.secondary" }}>
-                    {datasetDocument?.["dataset_description.json"]
-                      ?.BIDSVersion ?? "N/A"}
-                  </Typography>
-                </Box>
-                <Box>
-                  <Typography
-                    sx={{ color: Colors.darkPurple, fontWeight: "600" }}
-                  >
-                    References and Links
-                  </Typography>
-                  <Typography sx={{ color: "text.secondary" }}>
-                    {Array.isArray(
-                      datasetDocument?.["dataset_description.json"]
-                        ?.ReferencesAndLinks
-                    )
-                      ? datasetDocument["dataset_description.json"]
-                          .ReferencesAndLinks.length > 0
-                        ? datasetDocument[
-                            "dataset_description.json"
-                          ].ReferencesAndLinks.join(", ")
-                        : "N/A"
-                      : datasetDocument?.["dataset_description.json"]
-                          ?.ReferencesAndLinks ?? "N/A"}
-                  </Typography>
-                </Box>
-              </Box>
-            </Box>
+            <MetaDataPanel
+              datasetDocument={datasetDocument}
+              dbViewInfo={dbViewInfo}
+            />
           </Box>
         </Box>
 

--- a/src/services/neurojson.service.ts
+++ b/src/services/neurojson.service.ts
@@ -30,7 +30,9 @@ export const NeurojsonService = {
   },
   getDocumentById: async (dbName: string, documentId: string): Promise<any> => {
     try {
-      const response = await api.get(`${baseURL}/${dbName}/${documentId}`);
+      const response = await api.get(
+        `${baseURL}/${dbName}/${documentId}?revs_info=true`
+      );
       return response.data;
     } catch (error) {
       console.error(

--- a/src/utils/SearchPageFunctions/modalityLabels.ts
+++ b/src/utils/SearchPageFunctions/modalityLabels.ts
@@ -1,6 +1,8 @@
 export const modalityValueToEnumLabel: Record<string, string> = {
   anat: "Structural MRI (anat)",
+  mri: "Structural MRI (anat)",
   func: "fMRI (func)",
+  fmri: "fMRI (func)",
   dwi: "DWI (dwi)",
   fmap: "Field maps (fmap)",
   perf: "Perfusion (perf)",
@@ -11,5 +13,6 @@ export const modalityValueToEnumLabel: Record<string, string> = {
   pet: "PET (pet)",
   micr: "microscopy (micr)",
   nirs: "fNIRS (nirs)",
+  fnirs: "fNIRS (nirs)",
   motion: "motion (motion)",
 };


### PR DESCRIPTION
This PR implements the missing step in the search flow so users can see database-level matches even when dataset metadata doesn’t contain the keyword.
- resolves #81 
- the database card included: logo, name/fullname, modalities, dataset count, keyword highlight.

It also bundles several improvements to the dataset detail page.
- show accurate metadata size on download button.
- add revision select dropdown with link.